### PR TITLE
Issue #13: JSON logs appear in Sumo as strings

### DIFF
--- a/lambda-extensions/sumoclient/sumoclient.go
+++ b/lambda-extensions/sumoclient/sumoclient.go
@@ -197,7 +197,13 @@ func (s *sumoLogicClient) enhanceLogs(msg responseBody) {
 			if ok {
 				delete(item, "record")
 			}
-			item["message"] = strings.TrimSpace(message)
+			message = strings.TrimSpace(message)
+			json, err := utils.ParseJson(message)
+			if err != nil {
+				item["message"] = message
+			} else {
+				item["message"] = json
+			}
 		} else if ok && logType == "platform.report" {
 			s.createCWLogLine(item)
 		}

--- a/lambda-extensions/utils/utils.go
+++ b/lambda-extensions/utils/utils.go
@@ -71,3 +71,9 @@ func PrettyPrint(v interface{}) string {
 	}
 	return string(data)
 }
+
+// ParseJson to determine whether a string is valid JSON
+func ParseJson(s string) (js map[string]interface{}, err error) {
+	err = json.Unmarshal([]byte(s), &js)
+	return
+}


### PR DESCRIPTION
# PR Details

Address Issue 13: JSON logs appear in Sumo as strings

Currently using the sumo reflector lambda to forward CloudWatch Logs for Lambdas to sumo, log messages which are purely JSON are left as JSON so sumo auto-parse works on them. I found that the reflector specifically looks for JSON logs to handle them accordingly: https://github.com/SumoLogic/sumologic-aws-lambda/blob/90f280daf89d13d7f672101c5b3eec7081713a8b/cloudwatchlogs/cloudwatchlogs_lambda.js#L197-L203

The lambda extension formats all log messages as strings, even if they are JSON, which causes the JSON to have all double quotes escaped, requiring further parsing in queries and making for slower queries. 

## Description

in enhanceLogs, attempt to marshal log entry body as JSON into a map.
If successful, use the map as the log item message.
If unsuccessful, use the log entry body as a string as the log item message.

Built and deployed to a pre-prod AWS org where I was testing the public published extension, and configured my lambda to use this modified version in the PR, and I see JSON log messages being handled as expected now.

## Related Issue

https://github.com/SumoLogic/sumologic-lambda-extensions/issues/13

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Updated CHANGELOG.md. (didn't find a change log in the project)
- [x] Ran unit tests locally.
