### PR TITLE
Fixes Lambda Extension cost overruns

### DIFF
--- a/lambda-extensions/config/config.go
+++ b/lambda-extensions/config/config.go
@@ -36,7 +36,8 @@ type LambdaExtensionConfig struct {
 	SourceCategoryOverride string
 }
 
-var validLogTypes = []string{"platform", "function"}
+var defaultLogTypes = []string{"platform", "function"}
+var validLogTypes = []string{"platform", "function", "extension"}
 
 // GetConfig to get config instance
 func GetConfig() (*LambdaExtensionConfig, error) {
@@ -93,7 +94,7 @@ func (cfg *LambdaExtensionConfig) setDefaults() {
 		cfg.AWSLambdaRuntimeAPI = "127.0.0.1:9001"
 	}
 	if logTypes == "" {
-		cfg.LogTypes = validLogTypes
+		cfg.LogTypes = defaultLogTypes
 	} else {
 		cfg.LogTypes = strings.Split(logTypes, ",")
 	}

--- a/lambda-extensions/sumoclient/sumoclient_test.go
+++ b/lambda-extensions/sumoclient/sumoclient_test.go
@@ -31,6 +31,8 @@ func setupEnv() {
 	os.Setenv("SUMO_MAX_DATAQUEUE_LENGTH", "10")
 	os.Setenv("SUMO_MAX_CONCURRENT_REQUESTS", "3")
 	os.Setenv("SUMO_LOG_LEVEL", "DEBUG")
+	os.Setenv("SUMO_RETRY_SLEEP_TIME_MS", "50")
+	os.Setenv("SUMO_LOG_TYPES", "function")
 }
 
 func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {

--- a/lambda-extensions/sumologic-extension.go
+++ b/lambda-extensions/sumologic-extension.go
@@ -104,18 +104,17 @@ func processEvents(ctx context.Context) {
 			consumer.FlushDataQueue(ctx)
 			return
 		default:
+			logger.Debugf("switching to other go routine")
+			runtime.Gosched()
 			logger.Infof("Calling DrainQueue from processEvents")
-			for {
-				runtime_done := consumer.DrainQueue(ctx)
+			// for {
+			runtime_done := consumer.DrainQueue(ctx)
 
-				if runtime_done == 1 {
-					logger.Infof("Exiting DrainQueueLoop: Runtime is Done")
-					break
-				} else {
-					logger.Debugf("switching to other go routine")
-					runtime.Gosched()
-				}
+			if runtime_done == 1 {
+				logger.Infof("Exiting DrainQueueLoop: Runtime is Done")
+				break
 			}
+			// }
 
 			// This statement will freeze lambda
 			nextResponse, err := nextEvent(ctx)

--- a/lambda-extensions/sumologic-extension.go
+++ b/lambda-extensions/sumologic-extension.go
@@ -112,7 +112,6 @@ func processEvents(ctx context.Context) {
 
 			if runtime_done == 1 {
 				logger.Infof("Exiting DrainQueueLoop: Runtime is Done")
-				break
 			}
 			// }
 


### PR DESCRIPTION
# PR Details

This PR fixes the cost overrun as reported by many of our customers.
1. We no longer waits for runtime done event and calls next.
2. There is one more environment variable SUMO_RETRY_SLEEP_TIME_MS  introduced in this new version to configure the delay between retries.

## Checklist

- [ x] Updated CHANGELOG.md.
- [x ] Ran unit tests locally.
