### PR TITLE
Add feature switch for JSON log enhancement

### DIFF
--- a/lambda-extensions/config/config.go
+++ b/lambda-extensions/config/config.go
@@ -34,6 +34,7 @@ type LambdaExtensionConfig struct {
 	MaxDataPayloadSize     int
 	LambdaRegion           string
 	SourceCategoryOverride string
+	EnhanceJsonLogs        bool
 }
 
 var defaultLogTypes = []string{"platform", "function"}
@@ -73,6 +74,7 @@ func (cfg *LambdaExtensionConfig) setDefaults() {
 	maxConcurrentRequests := os.Getenv("SUMO_MAX_CONCURRENT_REQUESTS")
 	enableFailover := os.Getenv("SUMO_ENABLE_FAILOVER")
 	logTypes := os.Getenv("SUMO_LOG_TYPES")
+	enhanceJsonLogs := os.Getenv("SUMO_ENHANCE_JSON_LOGS")
 
 	if numRetry == "" {
 		cfg.NumRetry = 3
@@ -99,9 +101,11 @@ func (cfg *LambdaExtensionConfig) setDefaults() {
 		cfg.LogTypes = strings.Split(logTypes, ",")
 	}
 	if retrySleepTime == "" {
-		cfg.RetrySleepTime =  300 * time.Millisecond
+		cfg.RetrySleepTime = 300 * time.Millisecond
 	}
-
+	if enhanceJsonLogs == "" {
+		cfg.EnhanceJsonLogs = true
+	}
 }
 
 func (cfg *LambdaExtensionConfig) validateConfig() error {
@@ -111,6 +115,7 @@ func (cfg *LambdaExtensionConfig) validateConfig() error {
 	maxConcurrentRequests := os.Getenv("SUMO_MAX_CONCURRENT_REQUESTS")
 	enableFailover := os.Getenv("SUMO_ENABLE_FAILOVER")
 	retrySleepTime := os.Getenv("SUMO_RETRY_SLEEP_TIME_MS")
+	enhanceJsonLogs := os.Getenv("SUMO_ENHANCE_JSON_LOGS")
 
 	var allErrors []string
 	var err error
@@ -187,6 +192,13 @@ func (cfg *LambdaExtensionConfig) validateConfig() error {
 			cfg.LogLevel = customloglevel
 		}
 
+	}
+
+	if enhanceJsonLogs != "" {
+		cfg.EnhanceJsonLogs, err = strconv.ParseBool(enhanceJsonLogs)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("Unable to parse SUMO_ENHANCE_JSON_LOGS: %v", err))
+		}
 	}
 
 	// test valid log format type

--- a/lambda-extensions/sumoclient/sumoclient.go
+++ b/lambda-extensions/sumoclient/sumoclient.go
@@ -202,7 +202,11 @@ func (s *sumoLogicClient) enhanceLogs(msg responseBody) {
 			if err != nil {
 				item["message"] = message
 			} else {
-				item["message"] = json
+				if s.config.EnhanceJsonLogs {
+					item["message"] = json
+				} else {
+					item = json
+				}
 			}
 		} else if ok && logType == "platform.report" {
 			s.createCWLogLine(item)
@@ -287,7 +291,7 @@ func (s *sumoLogicClient) SendLogs(ctx context.Context, rawmsg []byte) error {
 }
 
 func (s *sumoLogicClient) SendAllLogs(ctx context.Context, allMessages [][]byte) error {
-	if (len(allMessages) == 0) {
+	if len(allMessages) == 0 {
 		s.logger.Debugf("SendAllLogs: No messages to send")
 		return nil
 	}


### PR DESCRIPTION
https://github.com/SumoLogic/sumologic-lambda-extensions/issues/13

Implement a feature switch to turn off log enhancement for JSON logs
Feature switch defaults to `true`, so behaviour is unchanged

# PR Details
Add a feature switch to turn off log enhancement for JSON logs

## Description
Implement a feature switch (via the enrivonment variable `SUMO_ENHANCE_JSON_LOGS`) which defaults to `true` so current behaviour remains unchanged. If the feature switch is set to `false` then the message sent to SumoLogic will not contain any addition metadata only the actual log message.

## Related Issue
https://github.com/SumoLogic/sumologic-lambda-extensions/issues/13

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Updated CHANGELOG.md. (there is no changelog file)
- [x] Ran unit tests locally.
