### PR TITLE
Checkin for lambda telemetry api support for extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Releasing new layer versions
      `sh zip.sh`
 
 
-- The new wheel package gets released automatically after the tags are pushed using Github actions(Refer tagged-release in https://github.com/marvinpinto/action-automatic-releases).
+- The new extension binary and zip files gets released automatically after the tags are pushed using Github actions(Refer tagged-release in https://github.com/marvinpinto/action-automatic-releases).
 
    Run below commands to create and push tags
 

--- a/lambda-extensions/config/version.go
+++ b/lambda-extensions/config/version.go
@@ -8,7 +8,7 @@ import (
 
 // ExtensionName same as binary name or file name where main exists
 var ExtensionName = filepath.Base(os.Args[0])
-var layerVersion = "4"
+var layerVersion = "7"
 
 // SumoLogicExtensionLayerVersionSuffix denotes the layer version published in AWS
 var SumoLogicExtensionLayerVersionSuffix string = fmt.Sprintf("%s-prod:%s", ExtensionName, layerVersion)

--- a/lambda-extensions/lambdaapi/telemetryapiclient.go
+++ b/lambda-extensions/lambdaapi/telemetryapiclient.go
@@ -1,0 +1,47 @@
+package lambdaapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// Base URL for telemetry api extension
+	telemetryURL = "2022-07-01/telemetry"
+	// Subscription Body Constants. Subscribe to platform logs and receive them on ${local_ip}:4243 via HTTP protocol.
+	telemetry_timeoutMs    = 1000
+	telemetry_maxBytes     = 1048576
+	telemetry_maxItems     = 10000
+	telemetry_receiverPort = 4243
+)
+
+// SubscribeToLogsAPI is - Subscribe to Logs API to receive the Lambda Logs.
+func (client *Client) SubscribeToTelemetryAPI(ctx context.Context, logEvents []string) ([]byte, error) {
+	URL := client.baseURL + telemetryURL
+
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"destination":   map[string]interface{}{"protocol": "HTTP", "URI": fmt.Sprintf("http://sandbox:%v", receiverPort)},
+		"types":         logEvents,
+		"buffering":     map[string]interface{}{"timeoutMs": telemetry_timeoutMs, "maxBytes": telemetry_maxBytes, "maxItems": telemetry_maxItems},
+		"schemaVersion": "2022-07-01",
+	})
+	if err != nil {
+		return nil, err
+	}
+	headers := map[string]string{
+		extensionIdentiferHeader: client.extensionID,
+	}
+	var response []byte
+	if ctx != nil {
+		response, err = client.MakeRequestWithContext(ctx, headers, bytes.NewBuffer(reqBody), "PUT", URL)
+	} else {
+		response, err = client.MakeRequest(headers, bytes.NewBuffer(reqBody), "PUT", URL)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}

--- a/lambda-extensions/lambdaapi/telemetryapiclient_test.go
+++ b/lambda-extensions/lambdaapi/telemetryapiclient_test.go
@@ -1,0 +1,35 @@
+package lambdaapi
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSubscribeToTelemetryAPI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertEqual(t, r.Method, http.MethodPut, "Method is not PUT")
+		assertNotEmpty(t, r.Header.Get(extensionNameHeader), "Extension Name Header not present")
+
+		reqBytes, err := ioutil.ReadAll(r.Body)
+		assertNoError(t, err, "Received error")
+		defer r.Body.Close()
+		assertNotEmpty(t, reqBytes, "Received error in request")
+
+		w.Header().Add(extensionIdentiferHeader, "test-sumo-id")
+		w.WriteHeader(200)
+	}))
+
+	defer srv.Close()
+	client := NewClient(srv.URL[7:], extensionName)
+
+	// Without Context
+	response, err := client.SubscribeToTelemetryAPI(nil, []string{"platform", "function", "extension"})
+	commonAsserts(t, client, response, err)
+
+	// With Context
+	response, err = client.SubscribeToTelemetryAPI(context.Background(), []string{"platform", "function", "extension"})
+	commonAsserts(t, client, response, err)
+}

--- a/lambda-extensions/sumologic-extension.go
+++ b/lambda-extensions/sumologic-extension.go
@@ -64,13 +64,14 @@ func runTimeAPIInit() (int64, error) {
 	}
 	logger.Debug("Succcessfully Registered with Run Time API Client: ", utils.PrettyPrint(registerResponse))
 
-	// Subscribe to Logs API
-	logger.Debug("Subscribing Extension to Logs API........")
-	subscribeResponse, err := extensionClient.SubscribeToLogsAPI(nil, config.LogTypes)
+	// Subscribe to Telemetry API
+	logger.Debug("Subscribing Extension to Telemetry API........")
+	subscribeResponse, err := extensionClient.SubscribeToTelemetryAPI(nil, config.LogTypes)
 	if err != nil {
 		return 0, err
 	}
-	logger.Debug("Successfully subscribed to Logs API: ", utils.PrettyPrint(string(subscribeResponse)))
+
+	logger.Debug("Successfully subscribed to Telemetry API: ", utils.PrettyPrint(string(subscribeResponse)))
 
 	// Call next to say registration is successful and get the deadtimems
 	nextResponse, err := nextEvent(nil)


### PR DESCRIPTION
# PR Details
Enhance AWS Lambda extension to incorporate Lambda Telemetry API to collect logs, metrics and spans (traces)
Provide a mechanism to drop spans if the user configures the environment variable. By default, spans are not to be dropped.

## Description
In config/config.go file
 - Flag related implementation is done - refer 
    - EnableSpanDrops
    - enableSpanDrops
    - SUMO_SPAN_DROP

In telemetryapiclient/telemetryapiclient.go file
New files are implemented for telemetry api support

In sumoclient/sumoclient.go file
Updated createCWLogLine(), enhanceLogs() to have new log supporting init duration, not dropping metrics and option to drop/not-drop spans

In sumologic-extension.go file
Updated runTimeAPIInit() for Subscribing Extension to Telemetry API

## Related Issue
Refer the PR details

## Checklist
- [x] Updated CHANGELOG.md.
- [x] Ran unit tests locally.